### PR TITLE
feat: clean up navbar and footer

### DIFF
--- a/app/RootLayout.tsx
+++ b/app/RootLayout.tsx
@@ -56,7 +56,7 @@ function NavBar({
         <Container className="">
             <div className="flex items-center justify-between">
                 <Link to="/" aria-label="Home">
-                    <Logo className="h-20 w-auto md:h-24" />
+                    <Logo className="h-10 w-auto" />
                 </Link>
                 <div className="flex items-center gap-x-6">
                     <Button

--- a/app/components/FadeIn.jsx
+++ b/app/components/FadeIn.jsx
@@ -3,7 +3,7 @@ import { motion, useReducedMotion } from 'framer-motion';
 
 const FadeInStaggerContext = createContext(false);
 
-const viewport = { once: true, margin: '0px 0px -200px' };
+const viewport = { once: true, margin: '0px 0px -120px' };
 
 export function FadeIn(props) {
     let shouldReduceMotion = useReducedMotion();

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -10,7 +10,7 @@ export function Footer() {
             <FadeIn>
                 <div className="mb-20 flex flex-col items-center justify-between gap-6 border-t border-neutral-950/10 pt-12 md:flex-row md:gap-0">
                     <Link to="/" aria-label="Home">
-                        <Logo className="h-20 w-auto md:h-24" />
+                        <Logo className="h-10 w-auto" />
                     </Link>
                     <SocialMedia />
                 </div>

--- a/app/components/Logo.jsx
+++ b/app/components/Logo.jsx
@@ -1,6 +1,6 @@
 export function Logo({ ...props }) {
     return (
-        <svg viewBox="0 0 792 612" {...props}>
+        <svg viewBox="200 150 392 312" {...props}>
             <style>{'.st3{fill:#eee}'}</style>
             <path d="M213.6 222.4h364.8v205.2c0 8.4-6.8 15.2-15.2 15.2H228.8c-8.4 0-15.2-6.8-15.2-15.2V222.4z" />
             <path


### PR DESCRIPTION
Cleaned up viewbox on logo SVG. Don't render excess whitespace. Reduce motion viewport offset to account for reduced footer height.